### PR TITLE
Fine-tune padding between photo, name, and title

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -6,6 +6,7 @@
   height: 40vmin;
   pointer-events: none;
   border-radius: 50%;
+  margin-bottom: 3rem;
 }
 
 .App-header {
@@ -17,6 +18,12 @@
   justify-content: center;
   font-size: calc(10px + 2vmin);
   color: white;
+}
+
+.App-header h1,
+.App-header h3 {
+  margin: 0;
+  padding: 0.3rem;
 }
 
 .App-link {


### PR DESCRIPTION
I didn't like the default spacing. This adds a little more padding between the photo and my name, and removes some between my name and title.

BEFORE:
![image](https://user-images.githubusercontent.com/29641878/222504836-27075436-9ea9-4747-8a28-abd0e7e43eb2.png)
(the scrollbar is from a different branch, please ignore it)

AFTER:
![image](https://user-images.githubusercontent.com/29641878/222505009-8fba4865-024b-4cde-a084-ccbbec28e7d7.png)
