### PR TITLE
remove redundant label

### DIFF
--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -3,7 +3,7 @@ import profile_photo from '../profile-photo.jpg';
 function Header () {
   return (
     <header className="App-header">
-      <img src={profile_photo} className="App-profile-photo" alt="profile photo" />
+      <img src={profile_photo} className="App-profile-photo" alt="profile" />
         <h1>Eric F. Olsen</h1>
         <p class="App-header-occupation">Software Engineer</p>
       </header>


### PR DESCRIPTION
Having "photo" in the img alt caused a warning because it's already implied it's an image of some sort, so this caused an error when building.