### PR TITLE
Fix occupation scaling

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -4,32 +4,6 @@
   color: white;
 }
 
-.App-profile-photo {
-  height: 40vmin;
-  pointer-events: none;
-  border-radius: 50%;
-  margin-bottom: 3rem;
-}
-
-.App-header {
-  min-height: 100vh;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  font-size: calc(10px + 2vmin);
-}
-
-.App-header h1,
-.App-header-occupation {
-  margin: 0;
-  padding: 0.3rem;
-}
-
-.App-header-occupation {
-  font-size: 2.5rem;
-}
-
 .App-link {
   color: #61dafb;
 }

--- a/src/components/Header.css
+++ b/src/components/Header.css
@@ -21,5 +21,5 @@
 }
 
 .App-header-occupation {
-  font-size: 2.5rem;
+  font-size: 1.5em;
 }

--- a/src/components/Header.css
+++ b/src/components/Header.css
@@ -1,0 +1,25 @@
+.App-profile-photo {
+  height: 40vmin;
+  pointer-events: none;
+  border-radius: 50%;
+  margin-bottom: 3rem;
+}
+
+.App-header {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  font-size: calc(10px + 2vmin);
+}
+
+.App-header h1,
+.App-header-occupation {
+  margin: 0;
+  padding: 0.3rem;
+}
+
+.App-header-occupation {
+  font-size: 2.5rem;
+}

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -5,7 +5,7 @@ function Header () {
     <header className="App-header">
       <img src={profile_photo} className="App-profile-photo" alt="profile" />
         <h1>Eric F. Olsen</h1>
-        <p class="App-header-occupation">Software Engineer</p>
+        <p className="App-header-occupation">Software Engineer</p>
       </header>
   );
 }

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,4 +1,5 @@
 import profile_photo from '../profile-photo.jpg';
+import './Header.css';
 
 function Header () {
   return (


### PR DESCRIPTION
This PR includes a few things. First, I accidentally a DOM property as "class=" when it should have been "className=", so I fixed that. While checking it, I noticed that when I adjusted the window size my name would scale but the occupation wouldn't, so on a large monitor it would be tiny, but when I made the window small it would appear huge. I fixed this by changing the CSS from using rem (relative to the element) to using em (relative to the parent element), and then played with size until I settled on 1.5. While doing all this, I decided I'd like to compartmentalize my code, so I took the header-related CSS out of App.css and moved it into its own Header.css at the same level as Header.js.


BEFORE:
![image](https://user-images.githubusercontent.com/29641878/224110288-253e544d-c726-47aa-ab4c-24542335d8f2.png)
![image](https://user-images.githubusercontent.com/29641878/224110343-8dacff06-cebb-43eb-8fae-e44d7ae17b58.png)

AFTER:
![image](https://user-images.githubusercontent.com/29641878/224108835-97c29429-1ace-49d9-9875-80931228dce9.png)
![image](https://user-images.githubusercontent.com/29641878/224108903-c7426ae2-7ef2-471b-9ef6-9faf17b534e9.png)
